### PR TITLE
GitHub action to update interop proposals with web-features-explorer data

### DIFF
--- a/.github/workflows/identify-web-features.yml
+++ b/.github/workflows/identify-web-features.yml
@@ -1,0 +1,25 @@
+# This GitHub Actions workflow identifies web features in new and edited issues.
+# Identified features are posted as a comment on the issue.
+name: Identify Web Features in Issues
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '22'
+      - name: Run identification script
+        run: |
+          cd scripts
+          npm install
+          node identify-web-features.js -n ${{ github.event.issue.number }} -r ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/scripts/identify-web-features.js
+++ b/scripts/identify-web-features.js
@@ -1,0 +1,303 @@
+import { Octokit } from "octokit";
+import { features } from "web-features";
+import yargs from "yargs";
+
+// This is used as a hidden HTML comment when posting comments to GitHub issues.
+// This way, we can retrieve the comment later, and update it if needed.
+const HIDDEN_COMMENT_IN_ISSUE = "<!-- interop-proposals-bot web-features update -->";
+const GITHUB_API_VERSION = "2022-11-28";
+
+const argv = yargs(process.argv)
+  .option("number", {
+    alias: "n",
+    type: "number",
+    default: false,
+    describe: "The issue number to process",
+  })
+  .option("repo", {
+    alias: "r",
+    type: "string",
+    describe: "The owner and repository name. For example: web-platform-tests/interop",
+  }).argv;
+
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+function escapeFeatureName(feature) {
+  // Escape the feature name for use in HTML.
+  return feature.name.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+async function getReferencedIssue() {
+  const response = await octokit.request(`GET /repos/${argv.repo}/issues/${argv.number}`,);
+  return response.data;
+}
+
+// Identify web-features based on spec URLs in the issue body.
+function gatherFeaturesFromSpecUrls(issueBody, gatheredFeatures) {
+  // Find URLs in the issue body.
+  const urls = issueBody.match(/https?:\/\/[^)\s]+/g) || [];
+
+  // Filter out known non-spec URLs.
+  const specUrls = urls
+    .filter(url => {
+      // Filter out known non-spec URLs.
+      return !url.includes("bugzilla") &&
+        !url.includes("github.com") &&
+        !url.includes("webkit.org") &&
+        !url.includes("developer.mozilla.org") &&
+        !url.includes("developer.chrome.com") &&
+        !url.includes("wpt.fyi") &&
+        !url.includes("css-tricks") &&
+        !url.includes("webstatus.dev") &&
+        !url.includes("learn.microsoft.com") &&
+        !url.includes("chromium.org");
+    }).map(url => {
+      // Separate the # from the URL if it exists.
+      return [url, url.split("#")[0]];
+    });
+
+  // Iterate over web features to find spec URL matches.
+  for (const [candidateUrl, candidateUrlNoAnchor] of specUrls) {
+    for (const id in features) {
+      const feature = features[id];
+      const featureSpecs = Array.isArray(feature.spec) ? feature.spec : [feature.spec];
+      if (featureSpecs.some(spec => spec === candidateUrl || spec === candidateUrlNoAnchor)) {
+        gatheredFeatures.add(id)
+      }
+    }
+  }
+}
+
+// Identify web-features based on explorer URLs in the issue body.
+function gatherFeaturesFromExplorerUrls(issueBody, gatheredFeatures) {
+  // https://web-platform-dx.github.io/web-features-explorer/features/<feature-id>
+  let urls = issueBody.match(/https?:\/\/web-platform-dx.github.io\/web-features-explorer\/features\/[a-z0-9-]+/g) || [];
+  urls = urls.map(url => url.split("#")[0]);
+
+  for (const url of urls) {
+    // Extract the feature ID from the URL.
+    const match = url.match(/features\/([a-z0-9-]+)/);
+    if (match && match[1]) {
+      const id = match[1];
+      const feature = features[id];
+      if (feature) {
+        gatheredFeatures.add(id);
+      }
+    }
+  }
+}
+
+// Identify web-features based on WPT URLs in the issue body.
+function gatherFeaturesFromWPTUrls(issueBody, gatheredFeatures) {
+  // https://wpt.fyi/results/?q=feature:<feature-id>
+  let urls = issueBody.match(/https?:\/\/wpt\.fyi\/results\/\?q=feature:[a-z0-9-]+/g) || [];
+  urls = urls.map(url => url.split("#")[0]);
+
+  for (const url of urls) {
+    // Extract the feature ID from the URL.
+    const match = url.match(/feature:([a-z0-9-]+)/);
+    if (match && match[1]) {
+      const id = match[1];
+      const feature = features[id];
+      if (feature) {
+        gatheredFeatures.add(id);
+      }
+    }
+  }
+}
+
+// Given a GitHub issue, find the web-features that are referenced in the issue body.
+// For now, we only look for URLs that match the web-features specifications.
+function findFeaturesInIssue(issue) {
+  const features = new Set();
+  
+  gatherFeaturesFromSpecUrls(issue.body, features);
+  gatherFeaturesFromExplorerUrls(issue.body, features);
+  gatherFeaturesFromWPTUrls(issue.body, features);
+  // TODO: Match on other things too:
+  // - web-features ID in the body of the issue, which might be there since the issue template asks for it.
+  // - MDN URLs
+  // - vendor positions
+  // - etc.
+  // Maybe investigate a weighting system to prioritize features based on the number of matches.
+
+  return [...features];
+}
+
+// Given a feature id, retrieve the feature's data.
+// We use the web-features-explorer's JSON files to get the full data, which includes both
+// the data that comes from the web-features project and the additional data that the explorer augments it with.
+async function getFeatureData(id) {
+  console.log(`Getting data for feature ${id}`);
+
+  try {
+    const response = await fetch(`https://web-platform-dx.github.io/web-features-explorer/features/${id}.json`);
+    return await response.json();
+  } catch (error) {
+    console.error(`Error fetching the feature data for ${id}:`, error);
+    return null;
+  }
+}
+
+function printBaselineStatus(feature) {
+  if (feature.status && feature.status.baseline === "high") {
+    return "Widely Available";
+  } else if (feature.status && feature.status.baseline === "low") {
+    return "Newly Available";
+  }
+  return "Limited Availability";
+}
+
+function printDocs(feature) {
+  if (!feature.mdnUrls.length) {
+    return "";
+  }
+
+  const docs = feature.mdnUrls.map(url => `[${url.title}](${url.url})`).join(", ");
+  return `* **Docs:** ${docs}\n`;
+}
+
+function printStandardPositions(feature) {
+  if (!feature.standardPositions.mozilla.url && !feature.standardPositions.webkit.url) {
+    return "";
+  }
+
+  let pos = "* **Standard positions:** ";
+
+  if (feature.standardPositions.mozilla.url) {
+    pos += `[Mozilla](${feature.standardPositions.mozilla.url})`;
+  }
+  if (feature.standardPositions.webkit.url) {
+    pos += (pos ? ", " : "") + `[WebKit](${feature.standardPositions.webkit.url})`;
+  }
+
+  return pos + "\n";
+}
+
+function printUseCounter(feature) {
+  if (!feature.useCounters.chromeStatusUrl) {
+    return "";
+  }
+  return `* **Chrome use counter:** [chromestatus.com](${feature.useCounters.chromeStatusUrl})\n`;
+}
+
+function printSurveys(feature) {
+  if (!feature.stateOfSurveys || !feature.stateOfSurveys.length) {
+    return "";
+  }
+
+  const surveys = feature.stateOfSurveys.map(survey => {
+    return `[${survey.name} (${survey.question} question)](${survey.link})`;
+  }).join(", ");
+
+  return `* **State of CSS/JS/HTML surveys:** ${surveys}\n`;
+}
+
+function printPreviousInterops(feature) {
+  if (!feature.interop.length) {
+    return "";
+  }
+
+  const interops = feature.interop.map(i => {
+    return `[${i.year}](https://wpt.fyi/interop-2024?feature=${i.label})`;
+  }).join(", ");
+
+  return `* **Included in previous Interop iterations:** ${interops}\n`
+}
+
+function printWPTLink(feature) {
+  if (!feature.wptLink) {
+    return "";
+  }
+  return `* **WPT tests:** [wpt.fyi](https://wpt.fyi/results/?q=feature:${feature.id})\n`;
+}
+
+// Generate the markdown content for the given feature.
+function getMarkdownContentForFeature(feature) {
+  let str = `### Feature **${escapeFeatureName(feature)}**\n\n`;
+  str += `* **ID:** ${feature.id}\n`;
+  str += `* **Name:** ${escapeFeatureName(feature)}\n`;
+  str += `* **Description:** ${feature.description_html}\n`;
+  str += `* **Baseline status:** ${printBaselineStatus(feature)}\n`;
+  str += printDocs(feature);
+  str += printStandardPositions(feature);
+  str += printUseCounter(feature);
+  str += printSurveys(feature);
+  str += printPreviousInterops(feature);
+  str += printWPTLink(feature);
+  str += `* **More information:** See the [web-features explorer](https://web-platform-dx.github.io/web-features-explorer/features/${feature.id}/).\n\n`;
+
+  return str;
+}
+
+// Post a new comment with the given markdown content or update an existing comment if it already exists.
+async function postOrUpdateComment(issueNumber, markdown) {
+  // Retrieve existing comments to check if we already posted a comment.
+  const commentsResponse = await octokit.request(`GET /repos/${argv.repo}/issues/${issueNumber}/comments`, {
+    headers: {
+      "X-GitHub-Api-Version": GITHUB_API_VERSION
+    }
+  });
+  const existingComment = commentsResponse.data.find(comment => comment.body.includes(HIDDEN_COMMENT_IN_ISSUE));
+
+  if (existingComment) {
+    // The bot already posted a comment. Update it.
+    console.log(`Updating existing comment #${existingComment.id}...`);
+    await octokit.request(`PATCH /repos/${argv.repo}/issues/comments/${existingComment.id}`, {
+      body: markdown,
+      headers: {
+        "X-GitHub-Api-Version": GITHUB_API_VERSION
+      }
+    });
+  } else {
+    // Post a new comment.
+    console.log(`Posting a new comment...`);
+    await octokit.request(`POST /repos/${argv.repo}/issues/${issueNumber}/comments`, {
+      body: markdown,
+      headers: {
+        "X-GitHub-Api-Version": GITHUB_API_VERSION
+      }
+    });
+  }
+}
+
+// The main entry point to the script.
+async function main() {
+  const issue = await getReferencedIssue();
+
+  console.log(`Processing issue #${issue.number}: "${issue.title}"`);
+  const featureIds = findFeaturesInIssue(issue);
+  const features = await Promise.all(featureIds.map(id => getFeatureData(id)));
+
+  if (features.length === 0) {
+    console.log("Could not find any matching features the issue body.");
+    return;
+  }
+
+  console.log(`Found ${features.length} matching feature(s):`);
+  console.log(features.map(f => `- ${f.id}`).join("\n"));
+
+  let content = "_This comment was automatically generated based on the information you provided. Please don't edit it._\n\n";
+  content += `Below is additional information about the web feature${features.length > 1 ? "s" : ""} (from the [web-features project](https://github.com/web-platform-dx/web-features/)) which ${features.length > 1 ? "are" : "is"} referenced in your proposal.`;
+  content += `This information might help motivate your focus area proposal.\n\n`;
+
+  for (const feature of features) {
+    const featureContent = getMarkdownContentForFeature(feature);
+
+    if (features.length > 1) {
+      content += `<details>\n`;
+      content += `<summary>${escapeFeatureName(feature)}</summary>\n\n`;
+      content += featureContent;
+      content += `</details>\n\n`;
+    } else {
+      content += featureContent;
+    }
+  }
+
+  // Add the hidden comment to find this comment again later.
+  content += `\n${HIDDEN_COMMENT_IN_ISSUE}`;
+
+  await postOrUpdateComment(issue.number, content);
+}
+
+main();

--- a/scripts/identify-web-features.js
+++ b/scripts/identify-web-features.js
@@ -217,7 +217,7 @@ function getPreviousInteropsAsMarkdown(feature) {
 }
 
 function getWPTLinkAsMarkdown(feature) {
-  if (!feature.wptLink) {
+  if (!feature.wpt) {
     return "";
   }
   return `* **WPT tests:** [wpt.fyi](https://wpt.fyi/results/?q=feature:${feature.id})\n`;

--- a/scripts/identify-web-features.js
+++ b/scripts/identify-web-features.js
@@ -286,7 +286,7 @@ async function main() {
     console.log("Could not find any matching features the issue body.");
 
     content += "No web features (from the [web-features project](https://github.com/web-platform-dx/web-features/)) were found in your proposal. If your proposal doesn't correspond to a web feature, that is fine.\\\n";
-    content += "Otherwise, please update your initial comment to include `web-features: <feature-id>`.";
+    content += "Otherwise, please update your initial comment to include `web-features: <feature-id>`.\n";
     content += "To find feature IDs, use the [web-features explorer](https://web-platform-dx.github.io/web-features-explorer/).\n\n";
 
   } else {
@@ -294,7 +294,7 @@ async function main() {
     console.log(features.map(f => `- ${f.id}`).join("\n"));
     
     content += `Below is additional information about the web feature${features.length > 1 ? "s" : ""} (from the [web-features project](https://github.com/web-platform-dx/web-features/)) which ${features.length > 1 ? "are" : "is"} referenced in your proposal.\\\n`;
-    content += "If this doesn't accurately correspond to your proposal, please update your initial comment to include `web-features: <feature-id>`.";
+    content += "If this doesn't accurately correspond to your proposal, please update your initial comment to include `web-features: <feature-id>`.\n";
     content += "To find feature IDs, use the [web-features explorer](https://web-platform-dx.github.io/web-features-explorer/).\n\n";
 
     for (const feature of features) {

--- a/scripts/identify-web-features.js
+++ b/scripts/identify-web-features.js
@@ -220,7 +220,7 @@ function getWPTLinkAsMarkdown(feature) {
   if (!feature.wpt) {
     return "";
   }
-  return `* **WPT tests:** [wpt.fyi](https://wpt.fyi/results/?q=feature:${feature.id})\n`;
+  return `* **WPT tests:** [wpt.fyi/results/?q=feature:${feature.id}](https://wpt.fyi/results/?q=feature:${feature.id})\n`;
 }
 
 // Generate the markdown content for the given feature.
@@ -236,7 +236,7 @@ function getMarkdownContentForFeature(feature) {
   str += getSurveysAsMarkdown(feature);
   str += getPreviousInteropsAsMarkdown(feature);
   str += getWPTLinkAsMarkdown(feature);
-  str += `* **More information:** See the [web-features explorer](https://web-platform-dx.github.io/web-features-explorer/features/${feature.id}/).\n\n`;
+  str += `* **More information:** See the [web-features explorer](https://web-platform-dx.github.io/web-features-explorer/features/${feature.id}/)\n\n`;
 
   return str;
 }

--- a/scripts/identify-web-features.js
+++ b/scripts/identify-web-features.js
@@ -106,7 +106,7 @@ function gatherFeaturesFromExplicitMentions(issueBody) {
   for (const mention of explicitMentions) {
     const match = mention.match(/web-features?:\s*([a-z0-9-]+)/i);
     if (match && match[1] && features[match[1]]) {
-      gatherFeatures.add(match[1]);
+      gatheredFeatures.add(match[1]);
     }
   }
 

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,644 @@
+{
+  "name": "interop-scripts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "interop-scripts",
+      "devDependencies": {
+        "octokit": "^5.0.3",
+        "web-features": "^2.40.2",
+        "yargs": "^18.0.0"
+      }
+    },
+    "node_modules/@octokit/app": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.0.1.tgz",
+      "integrity": "sha512-kgTeTsWmpUX+s3Fs4EK4w1K+jWCDB6ClxLSWUWTyhlw7+L3jHtuXDR4QtABu2GsmCMdk67xRhruiXotS3ay3Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-app": "^8.0.1",
+        "@octokit/auth-unauthenticated": "^7.0.1",
+        "@octokit/core": "^7.0.2",
+        "@octokit/oauth-app": "^8.0.1",
+        "@octokit/plugin-paginate-rest": "^13.0.0",
+        "@octokit/types": "^14.0.0",
+        "@octokit/webhooks": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.0.2.tgz",
+      "integrity": "sha512-dLTmmA9gUlqiAJZgozfOsZFfpN/OldH3xweb7lqSnngax5Rs+PfO5dDlokaBfc41H1xOtsLYV5QqR0DkBAtPmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.1",
+        "@octokit/auth-oauth-user": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.1.tgz",
+      "integrity": "sha512-TthWzYxuHKLAbmxdFZwFlmwVyvynpyPmjwc+2/cI3cvbT7mHtsAW9b1LvQaNnAuWL+pFnqtxdmrU8QpF633i1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.1",
+        "@octokit/auth-oauth-user": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.1.tgz",
+      "integrity": "sha512-TOqId/+am5yk9zor0RGibmlqn4V0h8vzjxlw/wYr3qzkQxl8aBPur384D1EyHtqvfz0syeXji4OUvKkHvxk/Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.0.tgz",
+      "integrity": "sha512-GV9IW134PHsLhtUad21WIeP9mlJ+QNpFd6V9vuPWmaiN25HEJeEQUcS4y5oRuqCm9iWDLtfIs+9K8uczBXKr6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.1",
+        "@octokit/oauth-methods": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.1.tgz",
+      "integrity": "sha512-qVq1vdjLLZdE8kH2vDycNNjuJRCD1q2oet1nA/GXWaYlpDxlR7rdVhX/K/oszXslXiQIiqrQf+rdhDlA99JdTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.3.tgz",
+      "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.1",
+        "@octokit/request": "^10.0.2",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.0.tgz",
+      "integrity": "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.1.tgz",
+      "integrity": "sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-app": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.1.tgz",
+      "integrity": "sha512-QnhMYEQpnYbEPn9cae+wXL2LuPMFglmfeuDJXXsyxIXdoORwkLK8y0cHhd/5du9MbO/zdG/BXixzB7EEwU63eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.1",
+        "@octokit/auth-oauth-user": "^6.0.0",
+        "@octokit/auth-unauthenticated": "^7.0.1",
+        "@octokit/core": "^7.0.2",
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/oauth-methods": "^6.0.0",
+        "@types/aws-lambda": "^8.10.83",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
+      "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.0.tgz",
+      "integrity": "sha512-Q8nFIagNLIZgM2odAraelMcDssapc+lF+y3OlcIPxyAU+knefO8KmozGqfnma1xegRDP4z5M73ABsamn72bOcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/openapi-webhooks-types": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.0.3.tgz",
+      "integrity": "sha512-90MF5LVHjBedwoHyJsgmaFhEN1uzXyBDRLEBe7jlTYx/fEhPAk3P3DAJsfZwC54m8hAIryosJOL+UuZHB3K3yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-graphql": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-6.0.0.tgz",
+      "integrity": "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.1.1.tgz",
+      "integrity": "sha512-q9iQGlZlxAVNRN2jDNskJW/Cafy7/XE52wjZ5TTvyhyOD904Cvx//DNyoO3J/MXJ0ve3rPoNWKEg5iZrisQSuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-16.0.0.tgz",
+      "integrity": "sha512-kJVUQk6/dx/gRNLWUnAWKFs1kVPn5O5CYZyssyEoNYaFedqZxsfYs7DwI3d67hGz4qOwaJ1dpm07hOAD1BXx6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.1.tgz",
+      "integrity": "sha512-KUoYR77BjF5O3zcwDQHRRZsUvJwepobeqiSSdCJ8lWt27FZExzb0GgVxrhhfuyF6z2B2zpO0hN5pteni1sqWiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=7"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.1.tgz",
+      "integrity": "sha512-S+EVhy52D/272L7up58dr3FNSMXWuNZolkL4zMJBNIfIxyZuUcczsQAU4b5w6dewJXnKYVgSHSV5wxitMSW1kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^7.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
+      "integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.0",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
+      "integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.1.1.tgz",
+      "integrity": "sha512-4kN/yPhcZEP+X7iMMuBTk+dD4ZGOpU57F7kHKrFlD2SSY/Sxh01t79oVn4npchLdPIXvLKrQw0uBXhmEaiZAdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-webhooks-types": "12.0.3",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/webhooks-methods": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
+      "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.150",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.150.tgz",
+      "integrity": "sha512-AX+AbjH/rH5ezX1fbK8onC/a+HyQHo7QGmvoxAE42n22OsciAxvZoZNEr22tbXs8WfP1nIsBjKDpgPm3HjOZbA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/octokit": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-5.0.3.tgz",
+      "integrity": "sha512-+bwYsAIRmYv30NTmBysPIlgH23ekVDriB07oRxlPIAH5PI0yTMSxg5i5Xy0OetcnZw+nk/caD4szD7a9YZ3QyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/app": "^16.0.1",
+        "@octokit/core": "^7.0.2",
+        "@octokit/oauth-app": "^8.0.1",
+        "@octokit/plugin-paginate-graphql": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^13.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^16.0.0",
+        "@octokit/plugin-retry": "^8.0.1",
+        "@octokit/plugin-throttling": "^11.0.1",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "@octokit/webhooks": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/web-features": {
+      "version": "2.41.2",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-2.41.2.tgz",
+      "integrity": "sha512-fzdUtsB62yni5EYV4EbRxWUlHMJ2zacA+qubtEGdwXu/IMlg9ytkt6kBeYiJ3MMl91PA0CU+azbFlXKN1VeZUw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "interop-scripts",
+  "type": "module",
+  "devDependencies": {
+    "octokit": "^5.0.3",
+    "web-features": "^2.40.2",
+    "yargs": "^18.0.0"
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "devDependencies": {
     "octokit": "^5.0.3",
-    "web-features": "^2.40.2",
+    "web-features": "^2.45.0",
     "yargs": "^18.0.0"
   }
 }


### PR DESCRIPTION
This is a PR for a proposal I made on a recent interop team meeting, also based on a discussion with @jgraham, and thanks to feedback I got from multiple people at that meeting.

The PR consists of a GitHub action which runs when a new issue is created, and when an existing issue is edited.
The action runs a NodeJS script (in the new `/scripts/` folder), which reads the issue body and attempts to find web-features that correspond to various URLs found in the body.

This can obviously be improved, but I wanted to open this PR early for a first round of feedback/review.

I don't know of a way to test GitHub actions without pushing changes to the main branch of a repo though, so I tested this on my own repo here: https://github.com/captainbrosset/interop-proposals-bot, and you can see a few issues which I experimented with: https://github.com/captainbrosset/interop-proposals-bot/issues

To test this further, feel free to create more issues on my repo.

So far, I mainly tested this in "happy path" scenarios, for example with a spec URL that actually matched a web-features entry. However, there are many focus area proposals from last year which don't return any web-features because they either don't have data we can use, or because the spec URL differs slightly.
So, one thing we should do here is test this with a bigger variety of existing issues and improve the web-features detection code accordingly.