### PR TITLE
Adding links for making proposals

### DIFF
--- a/.github/ISSUE_TEMPLATE/focus-area-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/focus-area-proposal.yml
@@ -7,7 +7,7 @@ body:
     value: |
       Thanks for taking the time to make a proposal for Interop 2026!
 
-      Be sure to read the [proposal guide](https://github.com/web-platform-tests/interop/blob/main/proposal_guide.md) to give your proposal the best chance of success!
+      Be sure to read the [proposal guide](https://github.com/web-platform-tests/interop/blob/main/making-a-proposal.md) to give your proposal the best chance of success!
 
       Note: If this feature is widely implemented, but lacks a high quality specification or tests, an [Investigation Effort](https://github.com/web-platform-tests/interop/issues/new?template=investigation-effort-proposal.yml) may be more appropriate.
 
@@ -51,7 +51,7 @@ body:
   attributes:
     label: Additional Signals
     description: |
-      Any additional signals from our [proposal guide](https://github.com/web-platform-tests/interop/blob/main/proposal_guide.md):
+      Any additional signals from our [proposal guide](https://github.com/web-platform-tests/interop/blob/main/making-a-proposal.md):
 
       - Standards Positions
       - Site Breakage and Workaround

--- a/2026/README.md
+++ b/2026/README.md
@@ -1,6 +1,6 @@
 # Interop 2026
 
-**Interop 2026 is now open for proposals!** Please submit your focus area and/or investigation area proposals [here](https://github.com/web-platform-tests/interop/issues/new/choose).
+**Interop 2026 is now open for proposals!** See the [proposal guide](../making-a-proposal.md) for details, and how to give your proposal the best chance of success.
 
 Interop 2026 is an effort to increase interoperability across browsers in key technical areas that are of high priority to web developers and end users. More details on the project are available in the [Interop Project README](https://github.com/web-platform-tests/interop/blob/main/README.md).
 
@@ -13,4 +13,4 @@ Interop 2026 is an effort to increase interoperability across browsers in key te
 
 ## Guidance for proposal authors
 
-If you would like to make a proposal for Interop 2026, we invite you to review the updated [Interop proposer's guide](https://github.com/web-platform-tests/interop/blob/main/proposal_guide.md) which offers valuable insights into the signals and criteria that Interop participants will consider when evaluating proposals. 
+If you would like to make a proposal for Interop 2026, we invite you to review the updated [Interop proposer's guide](https://github.com/web-platform-tests/interop/blob/main/proposal_guide.md) which offers valuable insights into the signals and criteria that Interop participants will consider when evaluating proposals.

--- a/2026/README.md
+++ b/2026/README.md
@@ -1,5 +1,7 @@
 # Interop 2026
 
+**Interop 2026 is now open for proposals!** Please submit your focus area and/or investigation area proposals [here](https://github.com/web-platform-tests/interop/issues/new/choose).
+
 Interop 2026 is an effort to increase interoperability across browsers in key technical areas that are of high priority to web developers and end users. More details on the project are available in the [Interop Project README](https://github.com/web-platform-tests/interop/blob/main/README.md).
 
 ## Timeline

--- a/2026/README.md
+++ b/2026/README.md
@@ -1,0 +1,14 @@
+# Interop 2026
+
+Interop 2026 is an effort to increase interoperability across browsers in key technical areas that are of high priority to web developers and end users. More details on the project are available in the [Interop Project README](https://github.com/web-platform-tests/interop/blob/main/README.md).
+
+## Timeline
+
+**Interop 2026 will open for proposals on September 4, 2025** and the overall timeline is as below. Please note that the timelines are subject to change.
+- Proposal submission window (~3 weeks): Sept 4th, 2025 through Sept 24th, 2025
+- Proposal selection: Before December 11th 2025
+- Scope of the Interop 2026 project published: the first half of February, 2026.
+
+## Guidance for proposal authors
+
+If you would like to make a proposal for Interop 2026, we invite you to review the updated [Interop proposer's guide](https://github.com/web-platform-tests/interop/blob/main/proposal_guide.md) which offers valuable insights into the signals and criteria that Interop participants will consider when evaluating proposals. 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Please see the [Interop 2024 Dashboard](https://wpt.fyi/interop-2024) and [Inter
 
 Please see the [Interop 2025 README](./2025/README.md) for the ongoing planning of Interop 2025, which will be announced in early 2025.
 
+## Proposing a focus area for 2026
+
+**Interop 2026 is now open for proposals!** See the [proposal guide](./making-a-proposal.md) for details, and how to give your proposal the best chance of success.
+
 ## The Purpose of the Interop Project
 
 *Improve interoperability significantly for the benefit of users and web developers.*

--- a/making-a-proposal.md
+++ b/making-a-proposal.md
@@ -16,7 +16,27 @@ or supplement these with their own specific considerations.
 
 For reference, here are some proposals from past years that are well structured. 
 Please note that the proposal template will have changes year over year. 
-We encourage you to read the guide in its entirety for the latest guidance. 
+We encourage you to read the guide in its entirety for the latest guidance.
+
+## Submitting a proposal
+
+Submit a proposal using one of the following links:
+
+- [Propose an Interop 2026 Focus
+  Area](https://github.com/web-platform-tests/interop/issues/new?template=focus-area-proposal.yml)
+  – for features that already have high quality specifications and
+  tests, but aren't implemented by all browsers.
+- [Proposal an Interop 2026 Investigation
+  Effort](https://github.com/web-platform-tests/interop/issues/new?investigation-effort-proposal.yml)
+  – for features that are widely implemented, but lack a high quality
+  specification or tests.
+
+To give your proposal the best chance of success, see the [essential
+criteria](#essential-criteria) below.
+
+If you want to propose a new feature for the web platform, please file
+an issue with the relevant group, such as [the
+CSSWG](https://github.com/w3c/csswg-drafts) for CSS features.
 
 <details>
   <summary>Example proposals</summary>

--- a/proposal_guide.md
+++ b/proposal_guide.md
@@ -4,33 +4,36 @@ As set out in the [README](README.md), the goal of the Interop project
 is to improve the web by making it easier to create websites and
 webapps that work well in every browser and browser engine.
 
-This guide will set out signals that participants will use when
-selecting focus areas, in order to help proposers understand what is
-likely to be accepted, and help them advocate for their proposal in
-the most effective way. Note that apart from those under "essential
-criteria", none of the items listed are considered binding, and
-different participants may use the criteria in different ways, or
-supplement these with their own specific considerations.
+This guide lists the signals that the Interop team uses when selecting
+focus areas, in order to help you understand what is likely to be
+accepted, and help you advocate for your proposal in the most
+effective way.
+
+Note that apart from those under Essential Criteria, none of the items
+listed are considered binding, and the different organizations that
+are part of the Interop team may use the criteria in different ways,
+or supplement these with their own specific considerations.
 
 ## Essential Criteria
 
 ### Testing
 
-Interop focus areas are scored by the pass rate of web platform
-tests. This means that to be accepted:
+Interop focus areas are scored by the pass rate of tests from the
+[Web Platform Tests project (WPT)](https://github.com/web-platform-tests/wpt).
+This means that, to be accepted:
 
-* The feature must be covered by web-platform-tests
+* The proposed feature must be covered by web-platform-tests.
 
 * The test coverage must be sufficient to represent a meaningful
   assessment of implementation quality and interoperability.
 
 * Tests must be fully automated and included in Chrome, Edge, Firefox
-  and Safari desktop runs on wpt.fyi.
+  and Safari desktop runs on [wpt.fyi](https://wpt.fyi/).
 
-Where there is insufficient test coverage during the proposal period,
-proposers can provide an indication of how they expect to achieve the
-necessary test coverage before the final focus areas are
-picked. Individual participants will judge how credible they consider
+If the feature you are proposing has insufficient test coverage during
+the proposal period, you can provide an indication of how you expect
+to achieve the necessary test coverage before the final focus areas
+are picked. The Interop team will judge how credible it considers
 these plans to be, and may choose to focus on proposals where tests
 are already available.
 
@@ -49,7 +52,7 @@ be required:
 
 * The areas of ongoing discussion are understood to be highly
   significant in terms of interoperability, have tentative tests, and
-  participants agree that reaching resolution on the outstanding
+  the Interop team agrees that reaching resolution on the outstanding
   questions is possible either before the Interop period starts or
   early in the Interop period.
 
@@ -60,12 +63,12 @@ be required:
 Interop is not intended as a venue to reach agreement on whether a
 feature is suitable for the web platform.
 
-Proposals covering features where participants have already indicated
-significant concerns, for example through standards-position
-repositories or similar public venues, are highly unlikely to be
-accepted. Proposers may of course work with participants to address
-their existing concerns before making an Interop proposal.
-
+Proposals covering features where individual participating
+organizations on the Interop team have already indicated significant
+concerns, for example through standards-position repositories or
+similar public venues, are highly unlikely to be accepted. You may of
+course work with these organizations to address their existing
+concerns before making an Interop proposal.
 
 ### Site Breakage and Workaround
 
@@ -81,7 +84,7 @@ developers today, for example:
 ### Size and Current State of the Feature
 
 Whether or not the feature is already widely implemented, and the
-confidence we have on full implementation being achievable:
+confidence you have on full implementation being achievable:
 
 * Features that are already widely implemented but have behavior
   differences may be considered more pressing than implementing new
@@ -91,17 +94,17 @@ confidence we have on full implementation being achievable:
   a higher priority than recently standardized features that are not
   yet implemented.
 
-* Use counter data might be considered, if it's showing a clear trend
-  and can be cleanly attributed to a real increase in use of the
-  feature. Past experience shows that absolute numbers in use counter
-  data can be misleading, so this is unlikely to carry much weight on
-  its own.
+* Use counter data, such as feature usage telemetry tracked by
+  browsers, might be considered, if it's showing a clear trend and can
+  be cleanly attributed to a real increase in use of the feature.
+  Past experience shows that absolute numbers in use counter data can
+  be misleading, so this is unlikely to carry much weight on its own.
 
 ### Browser Bugs
 
 Any evidence of developer demand in public bug trackers. For example:
 
-* +1 counts in the Chromium bug tracker.
+* +1 counts in the [Chromium bug tracker](https://issues.chromium.org/issues).
 
 ### Developer Surveys
 
@@ -109,15 +112,15 @@ Surveys indicating the degree of developer interest in a specific
 feature, or highlighting problems that the proposal is likely to
 address. For example:
 
-* State of HTML
-* State of CSS
-* State of JS
+* [State of HTML](https://stateofhtml.com/)
+* [State of CSS](https://stateofcss.com/)
+* [State of JS](https://stateofjs.com/)
 * Any MDN short survey
 * Other similar public surveys or data sources measuring interest in
   web platform features.
 
-Participants may also look at their internal research to understand
-developer sentiment around a feature.
+Participating organizations may also look at their internal research
+to understand developer sentiment around a feature.
 
 ### Other Developer Sentiment
 
@@ -146,7 +149,7 @@ likely to cause observable breakage:
 ### Platform Impact
 
 Whether the proposal is likely to have a positive impact on
-participants values for the web platform, for example:
+participating organizations' values for the web platform, for example:
 
 * Accessibility
 

--- a/proposal_guide.md
+++ b/proposal_guide.md
@@ -14,6 +14,18 @@ listed are considered binding, and the different organizations that
 are part of the Interop team may use the criteria in different ways,
 or supplement these with their own specific considerations.
 
+For reference, here are some proposals from past years that are well structured. 
+Please note that the proposal template will have changes year over year. 
+We encourage you to read the guide in its entirety for the latest guidance. 
+
+<details>
+  <summary>Example proposals</summary>
+  
+  - [View transition classes (Interop 2025)](https://github.com/web-platform-tests/interop/issues/767)
+  - [list-style-position on bare li elements (Interop 2025)](https://github.com/web-platform-tests/interop/issues/857)
+  - [backdrop-filter (Interop 2025)](https://github.com/web-platform-tests/interop/issues/822)
+</details>
+
 ## Essential Criteria
 
 ### Testing

--- a/proposal_guide.md
+++ b/proposal_guide.md
@@ -58,6 +58,14 @@ be required:
 
 ## Additional Signals
 
+### Web Features
+
+In some cases proposals may correspond to a specific
+[web-feature](https://web-platform-dx.github.io/web-features-explorer/).
+In these cases providing the web-feature id in the proposal will
+allow information about the feature, such as relevant standards positions,
+to be gathered and filled in automatically.
+
 ### Standards Positions
 
 Interop is not intended as a venue to reach agreement on whether a


### PR DESCRIPTION
- Rename `proposal_guide` to `making-a-proposal` to make it action-oriented and match other file name patterns
- Add links to filing different kinds of issues
- Point at this guide from other readmes