### PR TITLE
Identify web-features mentioned by name, rather than url

### DIFF
--- a/scripts/identify-web-features.js
+++ b/scripts/identify-web-features.js
@@ -98,7 +98,6 @@ function gatherFeaturesFromWPTUrls(urls) {
 
 // Identify web-features by checking for explicit mentions in the issue body.
 function gatherFeaturesFromExplicitMentions(issueBody) {
-  console.log(issueBody);
   const gatheredFeatures = new Set();
 
   // Look for `web-features: <feature-id>` or `web-feature: <feature-id>` in the issue body.
@@ -328,7 +327,7 @@ async function main() {
   // Add the hidden comment to find this comment again later.
   content += `\n${HIDDEN_COMMENT_IN_ISSUE}`;
 
-  // await postOrUpdateComment(issue.number, content);
+  await postOrUpdateComment(issue.number, content);
 }
 
 main();

--- a/scripts/identify-web-features.js
+++ b/scripts/identify-web-features.js
@@ -98,6 +98,7 @@ function gatherFeaturesFromWPTUrls(urls) {
 
 // Identify web-features by checking for explicit mentions in the issue body.
 function gatherFeaturesFromExplicitMentions(issueBody) {
+  console.log(issueBody);
   const gatheredFeatures = new Set();
 
   // Look for `web-features: <feature-id>` or `web-feature: <feature-id>` in the issue body.
@@ -107,6 +108,20 @@ function gatherFeaturesFromExplicitMentions(issueBody) {
     const match = mention.match(/web-features?:\s*([a-z0-9-]+)/i);
     if (match && match[1] && features[match[1]]) {
       gatheredFeatures.add(match[1]);
+    }
+  }
+
+  // Also look for an h3 markdown section like:
+  // ### web-feature
+  // <feature-id>
+  // The bug template includes this section. Note that there may be empty lines and spaces before or after the id.
+  const sectionMentions = issueBody.match(/###\s*web-features?\s*([\r\n]+[ \t]*[a-z0-9-]+)+/gi) || [];
+  for (const section of sectionMentions) {
+    const lines = section.split(/[\r\n]+/).map(line => line.trim()).filter(line => line && !line.startsWith("###"));
+    for (const line of lines) {
+      if (features[line]) {
+        gatheredFeatures.add(line);
+      }
     }
   }
 
@@ -288,7 +303,6 @@ async function main() {
     content += "No web features (from the [web-features project](https://github.com/web-platform-dx/web-features/)) were found in your proposal. If your proposal doesn't correspond to a web feature, that is fine.\\\n";
     content += "Otherwise, please update your initial comment to include `web-features: <feature-id>`.\n";
     content += "To find feature IDs, use the [web-features explorer](https://web-platform-dx.github.io/web-features-explorer/).\n\n";
-
   } else {
     console.log(`Found ${features.length} matching feature(s):`);
     console.log(features.map(f => `- ${f.id}`).join("\n"));
@@ -314,7 +328,7 @@ async function main() {
   // Add the hidden comment to find this comment again later.
   content += `\n${HIDDEN_COMMENT_IN_ISSUE}`;
 
-  await postOrUpdateComment(issue.number, content);
+  // await postOrUpdateComment(issue.number, content);
 }
 
 main();


### PR DESCRIPTION
The web-features identification github action fails to identify some known features.
For example: https://github.com/web-platform-tests/interop/issues/1007
The bot should successfully identify this one since the correct ID was mentioned.

Turns out, the bot was looking for (in addition to a bunch of known URLs) the following pattern: `web-features: id`.
This PR adds this additional pattern: `### web-features ... id`.