### PR TITLE
Avoid prefixing the webkit position with a coma if there's no mozilla position

### DIFF
--- a/scripts/identify-web-features.js
+++ b/scripts/identify-web-features.js
@@ -189,16 +189,16 @@ function getStandardPositionsAsMarkdown(feature) {
     return "";
   }
 
-  let pos = "* **Standard positions:** ";
+  const positions = [];
 
   if (feature.standardPositions.mozilla.url) {
-    pos += `[Mozilla](${feature.standardPositions.mozilla.url})`;
+    positions.push(`[Mozilla](${feature.standardPositions.mozilla.url})`);
   }
   if (feature.standardPositions.webkit.url) {
-    pos += (pos ? ", " : "") + `[WebKit](${feature.standardPositions.webkit.url})`;
+    positions.push(`[WebKit](${feature.standardPositions.webkit.url})`);
   }
 
-  return pos + "\n";
+  return "* **Standard positions:** " + positions.join(", ") + "\n";
 }
 
 function getUseCounterAsMarkdown(feature) {


### PR DESCRIPTION
If the web-features identification both finds a feature for which only WebKit has a standards position, then it creates a comment like this:

`Standard positions: , WebKit`

This fixes the formatting.