### PR TITLE
Markdown fix in proposal_guide.md

### DIFF
--- a/proposal_guide.md
+++ b/proposal_guide.md
@@ -20,9 +20,11 @@ We encourage you to read the guide in its entirety for the latest guidance.
 
 <details>
   <summary>Example proposals</summary>
+
   - [View transition classes (Interop 2025)](https://github.com/web-platform-tests/interop/issues/767)
   - [list-style-position on bare li elements (Interop 2025)](https://github.com/web-platform-tests/interop/issues/857)
   - [backdrop-filter (Interop 2025)](https://github.com/web-platform-tests/interop/issues/822)
+
 </details>
 
 ## Submitting a proposal


### PR DESCRIPTION
The `details` contents need empty lines to correctly render the markdown list.