### PR TITLE
Bump web-features to 2.48.0

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -7,7 +7,7 @@
       "name": "interop-scripts",
       "devDependencies": {
         "octokit": "^5.0.3",
-        "web-features": "^2.40.2",
+        "web-features": "^2.48.0",
         "yargs": "^18.0.0"
       }
     },
@@ -578,9 +578,9 @@
       "license": "ISC"
     },
     "node_modules/web-features": {
-      "version": "2.41.2",
-      "resolved": "https://registry.npmjs.org/web-features/-/web-features-2.41.2.tgz",
-      "integrity": "sha512-fzdUtsB62yni5EYV4EbRxWUlHMJ2zacA+qubtEGdwXu/IMlg9ytkt6kBeYiJ3MMl91PA0CU+azbFlXKN1VeZUw==",
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-2.48.0.tgz",
+      "integrity": "sha512-Qv/yRQP/gIQiMXF7XNCblDQDRQJ814PFArrjDvjXJnkVh80CulDMCIRaC4dB4Ex1ClE71xMwgjiBDdO8kcc48Q==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "devDependencies": {
     "octokit": "^5.0.3",
-    "web-features": "^2.45.0",
+    "web-features": "^2.48.0",
     "yargs": "^18.0.0"
   }
 }


### PR DESCRIPTION
Bumping the web-features dependency to 2.48.0 gives us a bunch of new features, which the web-features identification GH Action can then use to provide nice data to focus area proposal issues.
New features: heading-selectors, periodic-background-sync, viewport-segments, webauthn-signals, secure-payment-confirmation.