### PR TITLE
Upgrade to web-features 3.6.0

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -7,7 +7,7 @@
       "name": "interop-scripts",
       "devDependencies": {
         "octokit": "^5.0.3",
-        "web-features": "^2.48.0",
+        "web-features": "^3.6.0",
         "yargs": "^18.0.0"
       }
     },
@@ -578,9 +578,9 @@
       "license": "ISC"
     },
     "node_modules/web-features": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/web-features/-/web-features-2.48.0.tgz",
-      "integrity": "sha512-Qv/yRQP/gIQiMXF7XNCblDQDRQJ814PFArrjDvjXJnkVh80CulDMCIRaC4dB4Ex1ClE71xMwgjiBDdO8kcc48Q==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.6.0.tgz",
+      "integrity": "sha512-XuxKJvAvdTXDw3U3jcabcWNOFmQHWhTa69O0+crQDjpe5s0Odc4NNASImW1n77Gye7leBzKchVswGfO86ZbNPA==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "devDependencies": {
     "octokit": "^5.0.3",
-    "web-features": "^2.48.0",
+    "web-features": "^3.6.0",
     "yargs": "^18.0.0"
   }
 }


### PR DESCRIPTION
The web-features bot which we used during the proposal window uses an outdated version of the web-features data library.
This PR upgrades to 3.6.0, which is the latest version of the library, and fixes the code to account for the breaking changes that came with version 3.